### PR TITLE
Add source_type configuration; document OPenn values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The YAML inventory used to populate the guardian manifest should be in the follo
 
 ```YAML
 source: x
+source_type: x
 workspace: x
 compressed_destination: x
 compressed_extension: x
@@ -49,6 +50,12 @@ The values should correspond to:
 * `source` - The source on guardian for the content that will populate the archive
   * Valid term(s) for use with the Docker deployment:
     * `bulwark_gitannex_remote`
+    * NFS path to the directory containing the directories listed in `directortive_names`
+
+* `source_type` - The type of source for the content. If the type `git` is present, `.git` is appended to the `directive_name` value.
+  * Valid term(s) for use with the Docker deployment:
+    * `git` for source `bulwark_gitannex_remote`
+    * `directory` (or blank) for OPenn/rsync archives
 
 * `workspace` - The path on guardian where the archive will be pulled from the source and assembled into its compressed for
   * Valid term(s) for use with the Docker deployment:
@@ -68,11 +75,13 @@ The values should correspond to:
 
   * Supported application(s)
     * `bulwark`
+    * `openn`
 
 * `method` - The retrieval method required by the application to pull source content to the workspace so that it can be compressed and transferred
 
   * Supported method(s)
     * `gitannex`
+    * `rsync`
 
 * `description_values` - The key/value store of data apart from the directive name to add to the JSON blob of metadata for each archive transferred to Glacier.  The values `owner` and `location` are prepopulated in the example above, and any other key/value pairings can be added to the description metadata in the same way to your YAML file.
 

--- a/guardian_manifest.rb
+++ b/guardian_manifest.rb
@@ -5,7 +5,7 @@ require 'yaml'
 
 require 'pry'
 
-HEADERS = %w[todo_base source workspace compressed_destination glacier_description glacier_vault application method]
+HEADERS = %w[todo_base source source_type workspace compressed_destination glacier_description glacier_vault application method]
 
 def missing_args?
   return ARGV[0].nil?
@@ -18,7 +18,9 @@ def parse_inventory(yml)
     dir_entry = {}
     dir_entry['todo_base'] = dirname
     yaml['description_values']['description'] = dirname
-    dir_entry['source'] = "/#{yaml['source']}/#{dirname}.git"
+    dir_entry['source'] = "/#{yaml['source']}/#{dirname}"
+    dir_entry['source_type'] = yaml['source_type']
+    dir_entry['source'] += '.git' if yaml['source_type'] == 'git'
     dir_entry['workspace'] = "/#{yaml['workspace']}"
     dir_entry['compressed_destination'] = "#{yaml['compressed_destination']}/#{dirname}.#{yaml['compressed_extension']}"
     dir_entry['glacier_description'] = yaml['description_values'].to_s

--- a/inventory.yml.example
+++ b/inventory.yml.example
@@ -1,4 +1,5 @@
 source: x
+source_type: x
 workspace: x
 compressed_destination: x
 compressed_extension: x


### PR DESCRIPTION
Address issue #3. 

Adds a `source_type` YAML value. When `source_type` is `git`, `.git` is appended to the source in the CSV output. Also adds a `source_type` column to the CSV. Note that this change requires bulwark YAML files be changed to include the `source_type` value.

This pull request also includes documentation for openn-rsync YAML values.